### PR TITLE
Use version_compare rather than <

### DIFF
--- a/parallel-lint.php
+++ b/parallel-lint.php
@@ -1,8 +1,8 @@
 <?php
 use JakubOnderka\PhpParallelLint;
 
-if (PHP_VERSION < '5.3.2') {
-    die("PHP Parallel Lint require PHP 5.3.2 or newer.");
+if (!function_exists('version_compare') || version_compare(PHP_VERSION, '5.3.2', '<')) {
+    die("PHP Parallel Lint require PHP 5.3.2 or newer.\n");
 }
 
 const SUCCESS = 0,


### PR DESCRIPTION
The current code uses a string comparison to check the version number, this produces a false negative for e.g. '5.3.10' which is lexicographically less than '5.3.2'. Using PHP's built-in version_compare solves this issue.
