### PR TITLE
Force color output if it's switched on

### DIFF
--- a/src/Error.php
+++ b/src/Error.php
@@ -213,6 +213,7 @@ class SyntaxErrorColored extends SyntaxError
         }
 
         $colors = new ConsoleColor();
+        $colors->setForceStyle(true);
         $highlighter = new Highlighter($colors);
 
         $fileContent = file_get_contents($this->filePath);


### PR DESCRIPTION
The library which is used by the JakubOnderka/PHP-Console-Highlighter (kevinlebrun/colors.php) is using a detection mechanism to figure out if colors are supported. The [detection](https://github.com/kevinlebrun/colors.php/blob/1d1fed98dc6206fc7c94d7517ad0deff7ff46d0a/src/Colors/Color.php#L117) is using `posix_isatty` PHP function which evaluates if the STDOUT is an interactive terminal.

Since the lint is (I hope) supposed to be part of build tasks or it's output can be piped or redirected, then this detection evaluates the colors as not supported which does not have to be truth. All of the mentioned cases could display color control characters properly.

As mentioned above the **autodetection mechanism is not working reliably** in all situations and since there is an `--no-color` which can be used to suppress the colors anyway **I propose to set force the colors when they are switched on**. The coloring feature is optional anyway.

Other solution would be adding an `--force-colors` switch, but I guess it would make the switch options less readable.

It should probably be noted, that other tools designed to be used as part of continuous integration processes (composer, phpunit) are showing colors under these circumstances.
