### PR TITLE
Fix colored output after custom console color repository

### DIFF
--- a/src/Error.php
+++ b/src/Error.php
@@ -30,7 +30,7 @@ of the authors and should not be interpreted as representing official policies,
 either expressed or implied, of the FreeBSD Project.
  */
 
-use Colors\Color;
+use JakubOnderka\PhpConsoleColor\ConsoleColor;
 use JakubOnderka\PhpConsoleHighlighter\Highlighter;
 
 class Error
@@ -212,7 +212,7 @@ class SyntaxErrorColored extends SyntaxError
             return parent::getCodeSnippet($lineNumber, $linesBefore, $linesAfter);
         }
 
-        $colors = new Color();
+        $colors = new ConsoleColor();
         $highlighter = new Highlighter($colors);
 
         $fileContent = file_get_contents($this->filePath);


### PR DESCRIPTION
After colored output was changed from kevinlebrun, the namespace and classname has changed from `Colors\Color` to `JakubOnderka\PhpConsoleColor\ConsoleColor`. The code with its option to highlight colors does not reflect this change and throws an PHP error when a lint error was found.
