### PR TITLE
Remove unnecessary composer version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,6 @@
     "name": "jakub-onderka/php-parallel-lint",
     "description": "This tool check syntax of PHP files about 20x faster than serial check.",
     "homepage": "https://github.com/JakubOnderka/PHP-Parallel-Lint",
-    "version": "0.5",
     "license": "BSD",
     "require": {
         "php": ">=5.3.3"


### PR DESCRIPTION
As stated in the Composer schema documentation: https://getcomposer.org/doc/04-schema.md#version , the version should be omitted, if you are using a vcs.
