### PR TITLE
added PHP version 5.6 to Travis CI test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ php:
   - 5.3.3
   - 5.4
   - 5.5
+  - 5.6
 
 before_script:
   - composer self-update


### PR DESCRIPTION
We have actual version of PHP 5.6.0beta2, that is why I added this.
