### PR TITLE
Support HHVM

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ php:
   - 5.4
   - 5.5
   - 5.6
+  - hhvm
 
 before_script:
   - composer self-update

--- a/src/Process.php
+++ b/src/Process.php
@@ -237,20 +237,18 @@ class LintProcess extends Process
      */
     public static function getPhpExecutableVersion($phpExecutable)
     {
-        $process = new Process(escapeshellarg($phpExecutable) . ' -v');
+        $process = new Process(escapeshellarg($phpExecutable) . ' -r "echo PHP_VERSION_ID;"');
         $process->waitForFinish();
 
         if ($process->getStatusCode() !== 0 && $process->getStatusCode() !== 255) {
             throw new RunTimeException("Unable to execute '{$phpExecutable}'.");
         }
 
-        if (!preg_match('~PHP ([0-9]*).([0-9]*).([0-9]*)~', $process->getOutput(), $matches)) {
+        if (!preg_match('~([0-9]+)~', $process->getOutput(), $matches)) {
             throw new RunTimeException("'{$phpExecutable}' is not valid PHP binary.");
         }
 
-        $phpVersionId = $matches[1] * 10000 + $matches[2] * 100 + $matches[3];
-
-        return $phpVersionId;
+       return intval($matches[1]);
     }
 }
 


### PR DESCRIPTION
I ran into this when using composer to build a project on a server that uses HHVM with php54 compat. Composer satisfied the php version requirement with hhvm, but the test still failed (early on) inside PHP-Parallel-Lint. Its parent process uses `PHP_VERSION_ID` but the lint subprocesses fail due to it using `php -v`.

---

Blocked on nette/tester#156 going into a release.
