### PR TITLE
travis: Remove HHVM from allow_failures

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,6 @@ php:
 
 matrix:
   allow_failures:
-    - php: hhvm
     - php: hhvm-nightly
 
 before_script:


### PR DESCRIPTION
HHVM v3.3.0 fixes the unrelated problems we've been seeing.

Deployed on Travis CI as of 14 October 2014
http://blog.travis-ci.com/2014-10-08-october-2014-build-environment-update/
