### PR TITLE
Change readme ant task slightly

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,9 +54,11 @@ or setting for ANT:
 
 <target name="parallel-lint" description="Run PHP parallel lint">
     <exec executable="${parallel-lint}" failonerror="true">
-        <arg line='--exclude ${basedir}/app/' />
-        <arg line='--exclude ${basedir}/vendor/' />
-        <arg line='${basedir}' />
+        <arg line="--exclude" />
+        <arg path="${basedir}/app/" />
+        <arg line="--exclude" />
+        <arg path="${basedir}/vendor/" />
+        <arg path="${basedir}" />
     </exec>
 </target>
 ```


### PR DESCRIPTION
I'm not entirely sure why, but running this ant task as it was didn't behave correctly for me. It worked fine on a Mac, but didn't work on my Linux Jenkins box. I have a feeling it's something to do with my Linux Jenkins box having spaces in the file path.

This works fine though, and doesn't make any major differences I don't think.