### PR TITLE
Git blame is optional with CLI parameter --blame

### DIFF
--- a/parallel-lint.php
+++ b/parallel-lint.php
@@ -25,6 +25,7 @@ Options:
     --json      Output results as JSON string (require PHP 5.4).
     --git <git> Path to Git executable to show blame message (default: 'git').
     --stdin     Load files and folder to test from standard input.
+    --blame     Try to show git blame for row with error.
     -h, --help  Print this help.
 <?php
 }

--- a/src/Manager.php
+++ b/src/Manager.php
@@ -79,7 +79,9 @@ class Manager
 
         $result = $parallelLint->lint($files);
 
-        $this->gitBlame($result, $settings);
+        if ($settings->blame) {
+            $this->gitBlame($result, $settings);
+        }
 
         $output->writeResult($result, new ErrorFormatter($settings->colors, $translateTokens));
 

--- a/src/Settings.php
+++ b/src/Settings.php
@@ -93,6 +93,12 @@ class Settings
     public $stdin = false;
 
     /**
+     * Try to show git blame for row with error
+     * @var bool
+     */
+    public $blame = false;
+
+    /**
      * Path to git executable
      * @var string
      */
@@ -161,6 +167,10 @@ class Settings
 
                     case '--stdin':
                         $settings->stdin = true;
+                        break;
+
+                    case '--blame':
+                        $settings->blame = true;
                         break;
 
                     default:


### PR DESCRIPTION
Implemented 
``` bash
./parallel-lint --blame .
```
behavior from issue #43.