### PR TITLE
Add support for a phar file of PHP-Parallel-Lint

### DIFF
--- a/box.json
+++ b/box.json
@@ -1,0 +1,28 @@
+{
+    "output": "parallel-lint.phar",
+    "chmod": "0755",
+    "compactors": [
+        "Herrera\\Box\\Compactor\\Php"
+    ],
+    "extract": false,
+    "main": "parallel-lint.php",
+    "files": [
+        "LICENSE"
+    ],
+    "finder": [
+        {
+            "name": ["*.php"],
+            "exclude": ["Tests", "tests"],
+            "in": "vendor"
+        },
+        {
+            "exclude": ["Tests"],
+            "in": "src"
+        },
+        {
+            "in": "bin"
+        }
+    ],
+    "stub": true,
+    "web": false
+}

--- a/src/Process/SkipLintProcess.php
+++ b/src/Process/SkipLintProcess.php
@@ -18,7 +18,10 @@ class SkipLintProcess extends PhpProcess
      */
     public function __construct(PhpExecutable $phpExecutable, array $filesToCheck)
     {
-        $parameters = array('-n ' . escapeshellarg(__DIR__ . '/../../bin/skip-linting.php'));
+        $script = file_get_contents(__DIR__ . '/../../bin/skip-linting.php');
+        $script = str_replace('<?php', '', $script);
+
+        $parameters = array('-n -r ' . escapeshellarg($script));
 
         parent::__construct($phpExecutable, $parameters, implode("\n", $filesToCheck));
     }


### PR DESCRIPTION
As requested in #48 
Added a config file for box, box.json.
Changed the call of skip-linting.php, it is now executed inline, with php -r. This runs fine from within the phar-file.

To get it running:
- clone
- composer.phar up
- box.phar build

You can get box.phar here: https://github.com/box-project/box2