### PR TITLE
Remove allow failure for PHP7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,10 +8,6 @@ php:
   - 7.0
   - hhvm
 
-matrix:
-  allow_failures:
-    - php: 7.0
-
 sudo: false
 
 cache:


### PR DESCRIPTION
Remove allow failure for PHP version 7. Because new version comming soon and this library is stable for new PHP.
