### PR TITLE
Fix linting on Windows

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,27 @@
+build: off
+cache:
+    - c:\php -> appveyor.yml
+    - '%LOCALAPPDATA%\Composer\files -> appveyor.yml'
+
+clone_folder: c:\projects\php-parallel-lint
+
+init:
+    - SET PATH=c:\php;%PATH%
+    - SET INSTALL_PHP=1
+    - SET ANSICON=121x90 (121x90)
+
+install:
+    # Install PHP
+    - IF EXIST c:\php (SET INSTALL_PHP=0) ELSE (mkdir c:\php)
+    - IF %INSTALL_PHP%==1 cd c:\php
+    - IF %INSTALL_PHP%==1 appveyor DownloadFile http://windows.php.net/downloads/releases/archives/php-5.6.15-nts-Win32-VC11-x86.zip
+    - IF %INSTALL_PHP%==1 7z x php-5.6.15-nts-Win32-VC11-x86.zip >nul
+    - IF %INSTALL_PHP%==1 del /Q *.zip
+    - cd c:\projects\php-parallel-lint
+
+    # Install Composer dependencies
+    - appveyor DownloadFile https://getcomposer.org/composer.phar
+    - php composer.phar install --no-interaction --prefer-source --no-progress
+
+test_script:
+    - vendor\bin\tester tests -p php

--- a/bin/skip-linting.php
+++ b/bin/skip-linting.php
@@ -3,7 +3,7 @@ $stdin = fopen('php://stdin', 'r');
 $input = stream_get_contents($stdin);
 fclose($stdin);
 
-foreach (explode("\n", $input) as $file) {
+foreach (explode(PHP_EOL, $input) as $file) {
     $skip = false;
     $f = @fopen($file, 'r');
     if ($f) {
@@ -17,6 +17,6 @@ foreach (explode("\n", $input) as $file) {
         $skip = isset($m[2]) && !version_compare(PHP_VERSION, $m[2], $m[1]);
     }
 
-    echo "$file;" . ($skip ? '1' : '0') . "\n";
+    echo $file . ';' . ($skip ? '1' : '0') . PHP_EOL;
 }
 

--- a/src/Process/SkipLintProcess.php
+++ b/src/Process/SkipLintProcess.php
@@ -32,7 +32,7 @@ class SkipLintProcess extends PhpProcess
 
         $parameters = array('-n', '-r ' . escapeshellarg($script));
 
-        parent::__construct($phpExecutable, $parameters, implode("\n", $filesToCheck));
+        parent::__construct($phpExecutable, $parameters, implode(PHP_EOL, $filesToCheck));
     }
 
     public function getChunk()
@@ -77,7 +77,7 @@ class SkipLintProcess extends PhpProcess
     private function processLines($content)
     {
         if (!empty($content)) {
-            $lines = explode("\n", $this->endLastChunk . $content);
+            $lines = explode(PHP_EOL, $this->endLastChunk . $content);
             $this->endLastChunk = array_pop($lines);
             foreach ($lines as $line) {
                 $parts = explode(';', $line);


### PR DESCRIPTION
The changes from 0.9.1 in src/Process/SkipLintProcess.php to supply the content of bin/skip-linting.php to the command line via -r broke linting on Windows.

Apparently double quotes are not escaped correctly by escapeshellarg on Windows.

I also added an appveyor.yml for further automatic testing on Windows (as a starting point).
See build results [before](https://ci.appveyor.com/project/mdio/php-parallel-lint-kvimd/build/1.0.3) and [after](https://ci.appveyor.com/project/mdio/php-parallel-lint-kvimd/build/1.0.6).
