### PR TITLE
skiplintprocess: do not skip php.ini loading

### DIFF
--- a/src/Process/SkipLintProcess.php
+++ b/src/Process/SkipLintProcess.php
@@ -30,7 +30,7 @@ class SkipLintProcess extends PhpProcess
 
         $script = str_replace('<?php', '', $script);
 
-        $parameters = array('-n', '-r ' . escapeshellarg($script));
+        $parameters = array('-r ' . escapeshellarg($script));
 
         parent::__construct($phpExecutable, $parameters, implode(PHP_EOL, $filesToCheck));
     }


### PR DESCRIPTION
this fixes #79

the process is ran once per scan, so this is not performance critical step