### PR TITLE
Issue #78: added option to force colors

### DIFF
--- a/parallel-lint.php
+++ b/parallel-lint.php
@@ -28,6 +28,7 @@ Options:
     --exclude       Exclude directory. If you want exclude multiple directories, use
                     multiple exclude parameters.
     -j <num>        Run <num> jobs in parallel (default: 10).
+    --colors        Enable colors in console output. (disables auto detection of color support)
     --no-colors     Disable colors in console output.
     --json          Output results as JSON string (require PHP 5.4).
     --blame         Try to show git blame for row with error.

--- a/src/ErrorFormatter.php
+++ b/src/ErrorFormatter.php
@@ -35,7 +35,7 @@ use JakubOnderka\PhpConsoleHighlighter\Highlighter;
 
 class ErrorFormatter
 {
-    /** @var bool */
+    /** @var string */
     private $useColors;
 
     /** @var bool */
@@ -44,7 +44,7 @@ class ErrorFormatter
     /** @var bool */
     private $translateTokens;
 
-    public function __construct($useColors = false, $translateTokens = false, $forceColors = false)
+    public function __construct($useColors = Settings::AUTODETECT, $translateTokens = false, $forceColors = false)
     {
         $this->useColors = $useColors;
         $this->forceColors = $forceColors;
@@ -82,7 +82,7 @@ class ErrorFormatter
             $string .= ":$onLine" . PHP_EOL;
 
             if ($withCodeSnipped) {
-                if ($this->useColors) {
+                if ($this->useColors !== Settings::DISABLED) {
                     $string .= $this->getColoredCodeSnippet($error->getFilePath(), $onLine);
                 } else {
                     $string .= $this->getCodeSnippet($error->getFilePath(), $onLine);

--- a/src/ErrorFormatter.php
+++ b/src/ErrorFormatter.php
@@ -39,11 +39,15 @@ class ErrorFormatter
     private $useColors;
 
     /** @var bool */
+    private $forceColors;
+
+    /** @var bool */
     private $translateTokens;
 
-    public function __construct($useColors = false, $translateTokens = false)
+    public function __construct($useColors = false, $translateTokens = false, $forceColors = false)
     {
         $this->useColors = $useColors;
+        $this->forceColors = $forceColors;
         $this->translateTokens = $translateTokens;
     }
 
@@ -143,7 +147,7 @@ class ErrorFormatter
         }
 
         $colors = new ConsoleColor();
-        $colors->setForceStyle(true);
+        $colors->setForceStyle($this->forceColors);
         $highlighter = new Highlighter($colors);
 
         $fileContent = file_get_contents($filePath);

--- a/src/Manager.php
+++ b/src/Manager.php
@@ -107,7 +107,7 @@ class Manager
         if ($settings->json) {
             return new JsonOutput($writer);
         } else {
-            return ($settings->colors ? new TextOutputColored($writer) : new TextOutput($writer));
+            return ($settings->colors ? new TextOutputColored($writer, $settings->forceColors) : new TextOutput($writer));
         }
     }
 

--- a/src/Manager.php
+++ b/src/Manager.php
@@ -107,7 +107,10 @@ class Manager
         if ($settings->json) {
             return new JsonOutput($writer);
         } else {
-            return ($settings->colors !== Settings::DISABLED ? new TextOutputColored($writer, $settings->colors) : new TextOutput($writer));
+            if ($settings->colors === Settings::DISABLED) {
+                return new TextOutput($writer);
+            }
+            return new TextOutputColored($writer, $settings->colors);
         }
     }
 

--- a/src/Manager.php
+++ b/src/Manager.php
@@ -107,7 +107,7 @@ class Manager
         if ($settings->json) {
             return new JsonOutput($writer);
         } else {
-            return ($settings->colors ? new TextOutputColored($writer, $settings->forceColors) : new TextOutput($writer));
+            return ($settings->colors !== Settings::DISABLED ? new TextOutputColored($writer, $settings->colors) : new TextOutput($writer));
         }
     }
 

--- a/src/Output.php
+++ b/src/Output.php
@@ -320,13 +320,13 @@ class TextOutputColored extends TextOutput
     /** @var \JakubOnderka\PhpConsoleColor\ConsoleColor */
     private $colors;
 
-    public function __construct(IWriter $writer)
+    public function __construct(IWriter $writer, $forceColors = false)
     {
         parent::__construct($writer);
 
         if (class_exists('\JakubOnderka\PhpConsoleColor\ConsoleColor')) {
             $this->colors = new \JakubOnderka\PhpConsoleColor\ConsoleColor();
-            $this->colors->setForceStyle(true);
+            $this->colors->setForceStyle($forceColors);
         }
     }
 

--- a/src/Output.php
+++ b/src/Output.php
@@ -320,13 +320,13 @@ class TextOutputColored extends TextOutput
     /** @var \JakubOnderka\PhpConsoleColor\ConsoleColor */
     private $colors;
 
-    public function __construct(IWriter $writer, $forceColors = false)
+    public function __construct(IWriter $writer, $colors = Settings::AUTODETECT)
     {
         parent::__construct($writer);
 
         if (class_exists('\JakubOnderka\PhpConsoleColor\ConsoleColor')) {
             $this->colors = new \JakubOnderka\PhpConsoleColor\ConsoleColor();
-            $this->colors->setForceStyle($forceColors);
+            $this->colors->setForceStyle($colors === Settings::FORCED);
         }
     }
 

--- a/src/Settings.php
+++ b/src/Settings.php
@@ -81,6 +81,12 @@ class Settings
     public $colors = true;
 
     /**
+     * Do not autodetect if colors are available
+     * @var bool
+     */
+    public $forceColors = false;
+
+    /**
      * Output results as JSON string
      * @var bool
      */
@@ -156,6 +162,11 @@ class Settings
 
                     case '-j':
                         $settings->parallelJobs = max((int) $arguments->getNext(), 1);
+                        break;
+
+                    case '--colors':
+                        $settings->forceColors = true;
+                        $settings->colors = true;
                         break;
 
                     case '--no-colors':

--- a/src/Settings.php
+++ b/src/Settings.php
@@ -32,6 +32,14 @@ either expressed or implied, of the FreeBSD Project.
 
 class Settings
 {
+
+    /**
+     * constants for enum settings
+     */
+    const FORCED = 'FORCED';
+    const DISABLED = 'DISABLED';
+    const AUTODETECT = 'AUTODETECT';
+
     /**
      * Path to PHP executable
      * @var string
@@ -75,16 +83,10 @@ class Settings
     public $excluded = array();
 
     /**
-     * Print to console with colors
-     * @var bool
+     * Mode for color detection. Possible values: self::FORCED, self::DISABLED and self::AUTODETECT
+     * @var string
      */
-    public $colors = true;
-
-    /**
-     * Do not autodetect if colors are available
-     * @var bool
-     */
-    public $forceColors = false;
+    public $colors = self::AUTODETECT;
 
     /**
      * Output results as JSON string
@@ -165,12 +167,11 @@ class Settings
                         break;
 
                     case '--colors':
-                        $settings->forceColors = true;
-                        $settings->colors = true;
+                        $settings->colors = self::FORCED;
                         break;
 
                     case '--no-colors':
-                        $settings->colors = false;
+                        $settings->colors = self::DISABLED;
                         break;
 
                     case '--json':

--- a/tests/Settings.parseArguments.phpt
+++ b/tests/Settings.parseArguments.phpt
@@ -25,7 +25,7 @@ class SettingsParseArgumentsTest extends Tester\TestCase
         $expectedSettings->extensions = array('php', 'phtml', 'php3', 'php4', 'php5');
         $expectedSettings->paths = array('.');
         $expectedSettings->excluded = array();
-        $expectedSettings->colors = true;
+        $expectedSettings->colors = Settings::AUTODETECT;
         $expectedSettings->json = false;
 
         Assert::equal($expectedSettings->phpExecutable, $settings->phpExecutable);
@@ -53,7 +53,7 @@ class SettingsParseArgumentsTest extends Tester\TestCase
         $expectedSettings->extensions = array('php', 'phtml', 'php3', 'php4', 'php5');
         $expectedSettings->paths = array('.');
         $expectedSettings->excluded = array('vendor');
-        $expectedSettings->colors = false;
+        $expectedSettings->colors = Settings::DISABLED;
         $expectedSettings->json = false;
 
         Assert::equal($expectedSettings->phpExecutable, $settings->phpExecutable);
@@ -65,6 +65,18 @@ class SettingsParseArgumentsTest extends Tester\TestCase
         Assert::equal($expectedSettings->excluded, $settings->excluded);
         Assert::equal($expectedSettings->colors, $settings->colors);
         Assert::equal($expectedSettings->json, $settings->json);
+    }
+
+    public function testColorsForced()
+    {
+        $commandLine = "./parallel-lint --exclude vendor --colors .";
+        $argv = explode(" ", $commandLine);
+        $settings = Settings::parseArguments($argv);
+
+        $expectedSettings = new Settings();
+        $expectedSettings->colors = Settings::FORCED;
+
+        Assert::equal($expectedSettings->colors, $settings->colors);
     }
 }
 


### PR DESCRIPTION
Fixes: setForceStyle now only set on --color / on windows commandline without --no-color colors were set to output ( `......[41mX[0m[41mX[0m[43mS[0m.....`). 

Now
- without param it is auto detected by `JakubOnderka\PhpConsoleColor\ConsoleColor`
- with `--colors` colored output is forced, even if not supported 
- `--no-colors` a not colored output is forced, even if supported

Tested by me with Cmder (color support) and windows cmd.exe (no color support). Tests not failing.
