### PR TITLE
Fixed files skipping based on version_compare() in Windows

### DIFF
--- a/bin/skip-linting.php
+++ b/bin/skip-linting.php
@@ -10,11 +10,9 @@ foreach (explode(PHP_EOL, $input) as $file) {
         $firstLine = fgets($f);
         @fclose($f);
 
-        if (!preg_match('~<?php\\s*\\/\\/\s*lint\s*([^\d\s]+)\s*([^\s]+)\s*~i', $firstLine, $m)) {
-            $skip = false;
+        if (preg_match('~<?php\\s*\\/\\/\s*lint\s*([^\d\s]+)\s*([^\s]+)\s*~i', $firstLine, $m)) {
+            $skip = version_compare(PHP_VERSION, $m[2], $m[1]) === false;
         }
-
-        $skip = isset($m[2]) && !version_compare(PHP_VERSION, $m[2], $m[1]);
     }
 
     echo $file . ';' . ($skip ? '1' : '0') . PHP_EOL;


### PR DESCRIPTION
There's a strange bug in Windows when using `version_compare()`. The previous code `!version_compare(PHP_VERSION, $m[2], $m[1])` doesn't return expected values. However the strict comparison `=== false` works.

I added the strict comparison and simplified the code a little.