### PR TITLE
Strip tests/build files from packagist archive

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,7 @@
+/.gitattributes export-ignore
+/.gitignore export-ignore
+/.travis.yml export-ignore
+/appveyor.yml export-ignore
+/box.json export-ignore
+/phpcs-ruleset.xml export-ignore
+/tests/ export-ignore


### PR DESCRIPTION
When using 'composer require --prefer-dist' the vendor directory is
populated with build/CI and test files which are not needed to run the
application.

That causes various issues:
* production ends up with unrelated files, the test files notably could
  end up containing executing content which is most probably unwanted.
* an application build process might choke when running php -l as a
  safeguard for production. Specially it would choke on:
     tests/examples/example-03/example.php

Trying to keep a list of all ignores in the application build process is
tedious. I believe it is easier to just strip them directly at the
source.

People really needing the tests can 'composer require --prefer-source',
or git clone.

composer fetches the tarball generated by github.com which create the
tarball using 'git archive'. Using .gitattributes, one can exclude files
which are not strictly needed at run time.

To list files that would end up in the tar:
  git archive --worktree-attributes --format=tar HEAD|tar -t

To diff (assuming bash)
  diff -u <(git archive --format=tar HEAD^|tar -t) \
    <(git archive --worktree-attributes --format=tar HEAD|tar -t)