### PR TITLE
Look for fatal errors before syntax errors

### DIFF
--- a/src/Process/LintProcess.php
+++ b/src/Process/LintProcess.php
@@ -47,8 +47,16 @@ class LintProcess extends PhpProcess
     public function getSyntaxError()
     {
         if ($this->hasSyntaxError()) {
+            //Look for fatal errors first
             foreach (explode("\n", $this->getOutput()) as $line) {
-                if ($this->containsParserOrFatalError($line)) {
+                if ($this->containsFatalError($line)) {
+                    return $line;
+                }
+            }
+
+            //Look for parser errors second
+            foreach (explode("\n", $this->getOutput()) as $line) {
+                if ($this->containsParserError($line)) {
                     return $line;
                 }
             }
@@ -81,7 +89,24 @@ class LintProcess extends PhpProcess
      */
     private function containsParserOrFatalError($string)
     {
-        return strpos($string, self::FATAL_ERROR) !== false ||
-            strpos($string, self::PARSE_ERROR) !== false;
+        return $this->containsParserError($string) || $this->containsFatalError();
+    }
+
+    /**
+     * @param $string
+     * @return bool
+     */
+    private function containsParserError($string)
+    {
+        return strpos($string, self::PARSE_ERROR) !== false;
+    }
+
+    /**
+     * @param $string
+     * @return bool
+     */
+    private function containsFatalError($string)
+    {
+        return strpos($string, self::FATAL_ERROR) !== false;
     }
 }

--- a/src/Process/LintProcess.php
+++ b/src/Process/LintProcess.php
@@ -47,14 +47,14 @@ class LintProcess extends PhpProcess
     public function getSyntaxError()
     {
         if ($this->hasSyntaxError()) {
-            //Look for fatal errors first
+            // Look for fatal errors first
             foreach (explode("\n", $this->getOutput()) as $line) {
                 if ($this->containsFatalError($line)) {
                     return $line;
                 }
             }
 
-            //Look for parser errors second
+            // Look for parser errors second
             foreach (explode("\n", $this->getOutput()) as $line) {
                 if ($this->containsParserError($line)) {
                     return $line;

--- a/src/Process/LintProcess.php
+++ b/src/Process/LintProcess.php
@@ -89,7 +89,7 @@ class LintProcess extends PhpProcess
      */
     private function containsParserOrFatalError($string)
     {
-        return $this->containsParserError($string) || $this->containsFatalError();
+        return $this->containsParserError($string) || $this->containsFatalError($string);
     }
 
     /**


### PR DESCRIPTION
I was banging my head all morning until I finally understood what the problem was in #90 

This PR prioritizes fatal errors above parser errors, essentially **errors** above **warnings**.

I ran into the exact same problem mentioned by the OP, I had `declare(strict_types=1);` at the head of my file which is a warning for older versions of PHP but I also accidentally included a return type on one of my functions which is a fatal error for older versions. The warning can usually be safely ignored so the error should be exposed first.