### PR TITLE
Switch to Ubuntu 12.04/Precise for PHP 5.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,18 @@
 language: php
 
-php:
-  - 5.3.3
-  - 5.4
-  - 5.5
-  - 5.6
-  - 7.0
-  - 7.1
-  - hhvm
+matrix:
+  include:
+    - php: 5.3.3
+    - php: 5.4
+    - php: 5.5
+    - php: 5.6
+    - php: 7.0
+    - php: 7.1
+    - php: 7.2
+    - php: hhvm
+    - php: nightly
+  allow_failures:
+    - php: hhvm
 
 dist: precise
 sudo: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ php:
   - 7.1
   - hhvm
 
+dist: precise
 sudo: false
 
 cache:

--- a/src/Process/LintProcess.php
+++ b/src/Process/LintProcess.php
@@ -47,8 +47,16 @@ class LintProcess extends PhpProcess
     public function getSyntaxError()
     {
         if ($this->hasSyntaxError()) {
+            //Look for fatal errors first
             foreach (explode("\n", $this->getOutput()) as $line) {
-                if ($this->containsParserOrFatalError($line)) {
+                if ($this->containsFatalError($line)) {
+                    return $line;
+                }
+            }
+
+            //Look for parser errors second
+            foreach (explode("\n", $this->getOutput()) as $line) {
+                if ($this->containsParserError($line)) {
                     return $line;
                 }
             }
@@ -81,7 +89,24 @@ class LintProcess extends PhpProcess
      */
     private function containsParserOrFatalError($string)
     {
-        return strpos($string, self::FATAL_ERROR) !== false ||
-            strpos($string, self::PARSE_ERROR) !== false;
+        return $this->containsParserError($string) || $this->containsFatalError();
+    }
+
+    /**
+     * @param $string
+     * @return bool
+     */
+    private function containsParserError($string)
+    {
+        return strpos($string, self::PARSE_ERROR) !== false;
+    }
+
+    /**
+     * @param $string
+     * @return bool
+     */
+    private function containsFatalError($string)
+    {
+        return strpos($string, self::FATAL_ERROR) !== false;
     }
 }

--- a/src/Process/LintProcess.php
+++ b/src/Process/LintProcess.php
@@ -89,7 +89,7 @@ class LintProcess extends PhpProcess
      */
     private function containsParserOrFatalError($string)
     {
-        return $this->containsParserError($string) || $this->containsFatalError();
+        return $this->containsParserError($string) || $this->containsFatalError($string);
     }
 
     /**


### PR DESCRIPTION
Per the [blog post](https://blog.travis-ci.com/2017-08-31-trusty-as-default-status), [migration guide](https://docs.travis-ci.com/user/precise-to-trusty-migration-guide/) and [this issue](https://github.com/travis-ci/travis-ci/issues/8219) we need to explicitly state `dist: precise` to get Ubuntu 12.04/Precise in order to support PHP 5.3