### PR TITLE
be notified by the OS when processes are finished instead of polling …

### DIFF
--- a/src/ParallelLint.php
+++ b/src/ParallelLint.php
@@ -80,7 +80,7 @@ class ParallelLint
          * @var LintProcess[] $running
          * @var LintProcess[] $waiting
          */
-        $errors = $running = $waiting = array();
+        $errors = $running = $runningFiles = $waiting = array();
         $skippedFiles = $checkedFiles = array();
 
         while ($files || $running) {
@@ -99,6 +99,7 @@ class ParallelLint
                     );
                     $handle = $process->getResource();
                     $running[(int) $handle] = $handle;
+                    $runningFiles[(int) $handle] = $file;
                 }
             }
 
@@ -117,7 +118,8 @@ class ParallelLint
             }
 
             foreach ($running as $handle) {
-                unset($running[(int) $handle]);
+                $file = $runningFiles[(int) $handle];
+                unset($running[(int) $handle], $runningFiles[(int) $handle]);
 
                 // we know the process is finished, but we need to call this method
                 // to get the correct internal state

--- a/src/ParallelLint.php
+++ b/src/ParallelLint.php
@@ -91,22 +91,37 @@ class ParallelLint
                     $skippedFiles[] = $file;
                     $processCallback(self::STATUS_SKIP, $file);
                 } else {
-                    $running[$file] = new LintProcess(
+                    $process = new LintProcess(
                         $this->phpExecutable,
                         $file,
                         $this->aspTagsEnabled,
                         $this->shortTagEnabled
                     );
+                    $handle = $process->getResource();
+                    $running[(int) $handle] = $handle;
                 }
             }
 
             $skipLintProcess->getChunk();
-            usleep(100);
 
-            foreach ($running as $file => $process) {
+            // Error reporting suppressed since stream_select() emits an E_WARNING if it is interrupted by a signal.
+            $write = array();
+            $except = array();
+            if (!($result = @\stream_select($running, $write, $except, 0, 100))) {
+                if ($result !== 0) {
+                    $error = \error_get_last();
+                    if (\strpos($error["message"], "unable to select") === 0) {
+                        throw new \Exception($error["message"]);
+                    }
+                }
+            }
+
+            foreach ($running as $handle) {
+                unset($running[(int) $handle]);
+
+                // we know the process is finished, but we need to call this method
+                // to get the correct internal state
                 if ($process->isFinished()) {
-                    unset($running[$file]);
-
                     $skipStatus = $skipLintProcess->isSkipped($file);
                     if ($skipStatus === null) {
                         $waiting[$file] = $process;

--- a/src/Process/Process.php
+++ b/src/Process/Process.php
@@ -147,4 +147,13 @@ class Process
     {
         return $this->getStatusCode() === 1;
     }
+
+    /**
+     * Returns the underlying php resource handle
+     *
+     * @return resource
+     */
+    public function getResource() {
+        return $this->process;
+    }
 }


### PR DESCRIPTION
…the process_status over and over again.

this results in a 25% speedup in my codebase.

links only available for 30days.
before https://blackfire.io/profiles/0aeec0eb-892c-4ab9-8e78-0924ce2a6c60/graph
after https://blackfire.io/profiles/532f9f77-eb70-4c87-97da-b0d87d930b8d/graph
diff https://blackfire.io/profiles/compare/ea1161d7-7f5f-400b-9b06-c15286b0c139/graph