### PR TITLE
read skip-linting.php from path instead of passing the code arround

### DIFF
--- a/src/Process/SkipLintProcess.php
+++ b/src/Process/SkipLintProcess.php
@@ -22,15 +22,12 @@ class SkipLintProcess extends PhpProcess
     public function __construct(PhpExecutable $phpExecutable, array $filesToCheck)
     {
         $scriptPath = __DIR__ . '/../../bin/skip-linting.php';
-        $script = file_get_contents($scriptPath);
 
-        if (!$script) {
+        if (!is_readable($scriptPath)) {
             throw new RunTimeException("skip-linting.php script not found in '$scriptPath'.");
         }
 
-        $script = str_replace('<?php', '', $script);
-
-        $parameters = array('-d display_errors=stderr', '-r ' . escapeshellarg($script));
+        $parameters = array('-d display_errors=stderr', '-f ' . escapeshellarg($scriptPath));
 
         parent::__construct($phpExecutable, $parameters, implode(PHP_EOL, $filesToCheck));
     }


### PR DESCRIPTION
improves linting speed for a few percent and prevent unnecessary IO.