### PR TITLE
PHP 7.4: fix deprecation notice

### DIFF
--- a/src/Settings.php
+++ b/src/Settings.php
@@ -127,7 +127,7 @@ class Settings
         }
 
         foreach ($arguments as $argument) {
-            if ($argument{0} !== '-') {
+            if ($argument[0] !== '-') {
                 $settings->paths[] = $argument;
             } else {
                 switch ($argument) {


### PR DESCRIPTION
PHP 7.4 deprecates the use of curly braces for array/string character access.

See: https://wiki.php.net/rfc/deprecate_curly_braces_array_access