### PR TITLE
Composer: update `nette/tester` dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
         "ext-json": "*"
     },
     "require-dev": {
-        "nette/tester": "~1.3",
+        "nette/tester": "^1.3 || ^2.0",
         "jakub-onderka/php-console-highlighter": "~0.3",
         "squizlabs/php_codesniffer": "~2.7"
     },


### PR DESCRIPTION
This will allow the Nette Tester dependency to download different versions depending on the PHP version the tests are run on.