### PR TITLE
Script: allow running from git clone

### DIFF
--- a/parallel-lint
+++ b/parallel-lint
@@ -38,6 +38,7 @@ if (!defined('PHP_VERSION_ID') || PHP_VERSION_ID < 50400) {
 $autoloadLocations = [
     getcwd() . '/vendor/autoload.php',
     getcwd() . '/../../autoload.php',
+    __DIR__ . '/vendor/autoload.php',
     __DIR__ . '/../vendor/autoload.php',
     __DIR__ . '/../../../autoload.php',
 ];


### PR DESCRIPTION
If you git clone the repo and run `composer install` and then call the program like so:
```bash
php path/to/gitclone/parallel-lint/parallel-lint .
```
PHP-Parallel-Lint would fail with the following message:
```
You must set up the project dependencies, run the following commands:
curl -s http://getcomposer.org/installer | php
php composer.phar install
```

This small change allows the application to work correctly in that situation.