### PR TITLE
Tests/Settings.parseArguments: fix incorrect unit test

### DIFF
--- a/tests/Settings.parseArguments.phpt
+++ b/tests/Settings.parseArguments.phpt
@@ -90,7 +90,7 @@ class SettingsParseArgumentsTest extends Tester\TestCase
         $expectedSettings = new Settings();
         $expectedSettings->showProgress = false;
 
-        Assert::equal($expectedSettings->colors, $settings->colors);
+        Assert::equal($expectedSettings->showProgress, $settings->showProgress);
     }
 
     public function testJsonOutput()


### PR DESCRIPTION
The `testNoProgress()` test was not testing the `showProgress` property.