### PR TITLE
Allow for multi-part file extensions to be passed using -e

### DIFF
--- a/src/Manager.php
+++ b/src/Manager.php
@@ -134,7 +134,8 @@ class Manager
      */
     protected function getFilesFromPaths(array $paths, array $extensions, array $excluded = array())
     {
-        $extensions = array_flip($extensions);
+        $extensions = array_map('preg_quote', $extensions, array_fill(0, count($extensions), '`'));
+        $regex = '`\.(?:' . implode('|', $extensions) . ')$`iD';
         $files = array();
 
         foreach ($paths as $path) {
@@ -151,11 +152,11 @@ class Manager
                     \RecursiveIteratorIterator::CATCH_GET_CHILD
                 );
 
+                $iterator = new \RegexIterator($iterator, $regex);
+
                 /** @var \SplFileInfo[] $iterator */
                 foreach ($iterator as $directoryFile) {
-                    if (isset($extensions[pathinfo($directoryFile->getFilename(), PATHINFO_EXTENSION)])) {
-                        $files[] = (string) $directoryFile;
-                    }
+                    $files[] = (string) $directoryFile;
                 }
             } else {
                 throw new NotExistsPathException($path);

--- a/tests/Settings.parseArguments.phpt
+++ b/tests/Settings.parseArguments.phpt
@@ -108,6 +108,18 @@ class SettingsParseArgumentsTest extends Tester\TestCase
         $settings = Settings::parseArguments($argv);
         Assert::equal(Settings::FORMAT_CHECKSTYLE, $settings->format);
     }
+
+    public function testExtensions()
+    {
+        $commandLine = './parallel-lint -e php,php.dist,phpt .';
+        $argv = explode(" ", $commandLine);
+        $settings = Settings::parseArguments($argv);
+
+        $expectedSettings = new Settings();
+        $expectedSettings->extensions    = array('php', 'php.dist', 'phpt');
+
+        Assert::equal($expectedSettings->extensions, $settings->extensions);
+    }
 }
 
 $testCase = new SettingsParseArgumentsTest;


### PR DESCRIPTION
Implementation of feature request #115.

The user can now pass longer, multi-part extensions on the command-line and they will be respected.
Example:
`-e php,php.dist`

Fixes #115