### PR TITLE
Remove the curly braces notation for PHP 7.4

### DIFF
--- a/src/Settings.php
+++ b/src/Settings.php
@@ -127,7 +127,7 @@ class Settings
         }
 
         foreach ($arguments as $argument) {
-            if ($argument{0} !== '-') {
+            if ($argument[0] !== '-') {
                 $settings->paths[] = $argument;
             } else {
                 switch ($argument) {


### PR DESCRIPTION
Since PHP 7.4, the curly braces notation on array and string is [deprecated](https://www.php.net/manual/en/migration74.deprecated.php#migration74.deprecated.core.array-string-access-curly-brace). I just replaced it with a strpos to remove the warning (and possibly future error ?)