### PR TITLE
Remove in php8 deprecated curly braces access to string

### DIFF
--- a/src/Settings.php
+++ b/src/Settings.php
@@ -127,7 +127,7 @@ class Settings
         }
 
         foreach ($arguments as $argument) {
-            if ($argument{0} !== '-') {
+            if (strpos($argument, '-') !== 0) {
                 $settings->paths[] = $argument;
             } else {
                 switch ($argument) {


### PR DESCRIPTION
parallel-lint works fine with php8, only one deprecated string access, which is fixed by this PR.